### PR TITLE
Drop python 3.9 for compatibility with `lm-eval==0.4.9.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.2.4"
 description = ""
 license = "MIT"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "accelerate>=0.26.0",
     "anthropic>=0.25.7",


### PR DESCRIPTION
This pull request updates the minimum required Python version from 3.9 to 3.10.


When we run `uv sync` we got the following error:
```bash
uv sync
Using CPython 3.13.8 interpreter at: /usr/local/bin/python3
Creating virtual environment at: .venv
  × No solution found when resolving dependencies:
  ╰─▶ Because the requested Python version (>=3.9) does not satisfy
      Python>=3.10 and lm-eval==0.4.9.1 depends on Python>=3.10, we can
      conclude that lm-eval==0.4.9.1 cannot be used.
      And because only lm-eval==0.4.9.1 is available and your project depends
      on lm-eval, we can conclude that your project's requirements are
      unsatisfiable.

      hint: The `requires-python` value (>=3.9) includes Python versions that
      are not supported by your dependencies (e.g., lm-eval==0.4.9.1 only
      supports >=3.10). Consider using a more restrictive `requires-python`
      value (like >=3.10).
```
This PR resolves the error by dropping python 3.9 support.